### PR TITLE
Adding argument passing logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+__pycache__

--- a/general.py
+++ b/general.py
@@ -8,6 +8,16 @@ def create_project_dir(directory):
         os.makedirs(directory)
 
 
+# Remove queue and crawled files (if exist)
+def remove_data_files(project_name, base_url):
+    queue = project_name + '/queue.txt'
+    crawled = project_name + '/crawled.txt'
+    if os.path.isfile(queue):
+        os.remove(queue)
+    if os.path.isfile(crawled):
+        os.remove(crawled)
+
+
 # Create queue and crawled files (if not created)
 def create_data_files(project_name, base_url):
     queue = project_name + '/queue.txt'

--- a/general.py
+++ b/general.py
@@ -21,7 +21,7 @@ def create_data_files(project_name, base_url):
 # Create a new file
 def write_file(path, data):
     with open(path, 'w') as f:
-    f.write(data)
+        f.write(data)
 
 
 # Add data onto an existing file

--- a/link_finder.py
+++ b/link_finder.py
@@ -10,7 +10,8 @@ class LinkFinder(HTMLParser):
         self.page_url = page_url
         self.links = set()
 
-    # When we call HTMLParser feed(), this function is called when it encounters an opening tag <a>
+    # When we call HTMLParser feed(),
+    # this function is called when it encounters an opening tag <a>
     def handle_starttag(self, tag, attrs):
         if tag == 'a':
             for (attribute, value) in attrs:

--- a/main.py
+++ b/main.py
@@ -1,8 +1,19 @@
 import threading
+import argparse
 from queue import Queue
 from spider import Spider
 from domain import *
 from general import *
+
+parser = argparse.ArgumentParser(
+    description="Multi-threaded website crawler written in Python.")
+
+parser.add_argument(
+    "--flush",
+    help="empty project folder prior to crawling",
+    action="store_true")
+
+args = parser.parse_args()
 
 PROJECT_NAME = 'example'
 HOMEPAGE = 'http://example.com/'
@@ -12,7 +23,15 @@ QUEUE_FILE = PROJECT_NAME + '/queue.txt'
 CRAWLED_FILE = PROJECT_NAME + '/crawled.txt'
 NUMBER_OF_THREADS = 8
 queue = Queue()
-Spider(PROJECT_NAME, HOMEPAGE, DOMAIN_NAME)
+
+attrs = {
+    'project_name': PROJECT_NAME,
+    'base_url': HOMEPAGE,
+    'domain_name': DOMAIN_NAME,
+    'flush': args.flush
+}
+
+Spider(attrs)
 
 
 # Create worker threads (will die when main exits)

--- a/spider.py
+++ b/spider.py
@@ -14,12 +14,14 @@ class Spider:
     queue = set()
     crawled = set()
 
-    def __init__(self, project_name, base_url, domain_name):
-        Spider.project_name = project_name
-        Spider.base_url = base_url
-        Spider.domain_name = domain_name
+    def __init__(self, attrs):
+        Spider.project_name = attrs['project_name']
+        Spider.base_url = attrs['base_url']
+        Spider.domain_name = attrs['domain_name']
         Spider.queue_file = Spider.project_name + '/queue.txt'
         Spider.crawled_file = Spider.project_name + '/crawled.txt'
+        if(attrs["flush"]):
+            remove_data_files(Spider.project_name, Spider.base_url)
         self.boot()
         self.crawl_page('Initializer', Spider.base_url)
 


### PR DESCRIPTION
First, great to meet you, this is a great idea and repo.

Change in this PR is aimed for a more convenient testing/development/automation.

Introducing `--flush` argument for a `main.py` script. When argument is there, Spider deletes existing data from data files -- `query.txt` and `crawled.txt` -- before doing any crawling. In other words, every run with `--flush` on the same config does the crawling anew on chosen `HOMEPAGE`.

I've also pinned down a few `flake8` issues, and fixed a minor indentation error which crashes the script in its current state.