### PR TITLE
Twitter - Unable to scrape twitter.com

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ from general import *
 args = docopt(__doc__)
 
 PROJECT_NAME = 'example'
-HOMEPAGE = 'http://twitter.com/'
+HOMEPAGE = 'http://www.example.com/'
 DOMAIN_NAME = get_domain_name(HOMEPAGE)
 
 QUEUE_FILE = PROJECT_NAME + '/queue.txt'

--- a/main.py
+++ b/main.py
@@ -1,3 +1,14 @@
+"""Multi-threaded website crawler written in Python.
+
+Usage:
+    main.py  [--flush]
+
+Options:
+    -h --help   Show this screen.
+    --flush     Empty project folder prior to crawling [default: True].
+
+"""
+from docopt import docopt
 import threading
 import argparse
 from queue import Queue
@@ -5,15 +16,9 @@ from spider import Spider
 from domain import *
 from general import *
 
-parser = argparse.ArgumentParser(
-    description="Multi-threaded website crawler written in Python.")
 
-parser.add_argument(
-    "--flush",
-    help="empty project folder prior to crawling",
-    action="store_true")
-
-args = parser.parse_args()
+args = docopt(__doc__)
+print(args)
 
 PROJECT_NAME = 'example'
 HOMEPAGE = 'http://example.com/'
@@ -28,7 +33,7 @@ attrs = {
     'project_name': PROJECT_NAME,
     'base_url': HOMEPAGE,
     'domain_name': DOMAIN_NAME,
-    'flush': args.flush
+    'flush': args['--flush']
 }
 
 Spider(attrs)

--- a/main.py
+++ b/main.py
@@ -1,11 +1,11 @@
 """Multi-threaded website crawler written in Python.
 
 Usage:
-    main.py  [--flush]
+    main.py  [--flush=<boolean>]
 
 Options:
-    -h --help   Show this screen.
-    --flush     Empty project folder prior to crawling [default: True].
+    -h --help           Show this screen.
+    --flush=<boolean>   Empty project folder prior to crawling [default: True].
 
 """
 from docopt import docopt
@@ -18,7 +18,6 @@ from general import *
 
 
 args = docopt(__doc__)
-print(args)
 
 PROJECT_NAME = 'example'
 HOMEPAGE = 'http://example.com/'

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ from general import *
 args = docopt(__doc__)
 
 PROJECT_NAME = 'example'
-HOMEPAGE = 'http://example.com/'
+HOMEPAGE = 'http://twitter.com/'
 DOMAIN_NAME = get_domain_name(HOMEPAGE)
 
 QUEUE_FILE = PROJECT_NAME + '/queue.txt'

--- a/spider.py
+++ b/spider.py
@@ -45,7 +45,8 @@ class Spider:
         html_string = ''
         try:
             response = urlopen(page_url)
-            if response.getheader('Content-Type') == 'text/html':
+            if response.getheader('Content-Type') == 'text/html' or \
+                    response.getheader('content-type') == 'text/html;charset=utf-8':
                 html_bytes = response.read()
                 html_string = html_bytes.decode("utf-8")
             finder = LinkFinder(Spider.base_url, page_url)


### PR DESCRIPTION
Issue reported that no links were being scraped from twitter.com.  The problem was the difference in the naming of the header 'Content-Type' parameter retrieved from twitter.com.  The header parameter was lowercase, 'content-type' instead of 'Content-Type' that was specificied in the code. Also twitter.com response for  'content-type' is 'text/html;charset=utf-8' not 'text/html'.  I fixed this by added an 'or' logical.

 