### PR TITLE
Changed delete_file_contents to be more readable and pythonic

### DIFF
--- a/general.py
+++ b/general.py
@@ -32,8 +32,7 @@ def append_to_file(path, data):
 
 # Delete the contents of a file
 def delete_file_contents(path):
-    with open(path, 'w'):
-        pass
+    open(path, 'w').close()
 
 
 # Read a file and convert each line to set items


### PR DESCRIPTION
Pretty self explanatory, instead of using open and pass you can just open (in write mode) and close the file to delete its contents. Makes the code cleaner, shorter, and more readable. 

It's also very slightly faster:
```
Admin@Admin-PC MINGW64 ~/Desktop
$ python -m timeit 'with open("test.txt", "w"): pass'
10000 loops, best of 3: 63.7 usec per loop

Admin@Admin-PC MINGW64 ~/Desktop
$ python -m timeit 'open("test.txt", "w").close()'
10000 loops, best of 3: 63.2 usec per loop

```

References:
http://stackoverflow.com/questions/2769061/how-to-erase-the-file-contents-of-text-file-in-python
http://stackoverflow.com/questions/4914277/how-to-empty-a-file-using-python
